### PR TITLE
Debug negative step size in LeadingLog module

### DIFF
--- a/EventGenerator/src/LeadingLog_module.cc
+++ b/EventGenerator/src/LeadingLog_module.cc
@@ -26,6 +26,7 @@
 
 #include "Offline/SeedService/inc/SeedService.hh"
 #include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
+#include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
 #include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/StageParticle.hh"
@@ -95,6 +96,7 @@ namespace mu2e {
   {
     produces<mu2e::StageParticleCollection>();
     pid_ = static_cast<PDGCode::type>(pdgId_);
+    _mass = GlobalConstantsHandle<ParticleDataList>()->particle(pid_).mass();
 
     if (pid_ == PDGCode::e_minus) {
       process_ = ProcessCode::mu2eCeMinusLeadingLog;

--- a/Mu2eKinKal/inc/KKStrawXing.hh
+++ b/Mu2eKinKal/inc/KKStrawXing.hh
@@ -85,6 +85,7 @@ namespace mu2e {
       auto const& straw() const { return straw_; }
       auto const& strawId() const { return straw_.id(); }
       auto const& strawHitPtr() const { return shptr_; }
+      void updateFromHit(KKSTRAWHITPTR const& strawhit, CA const& ca);
     private:
       StrawXingUpdater sxconfig_; // cache of most recent update
       KKSTRAWHITPTR shptr_; // reference to associated StrawHit
@@ -127,6 +128,12 @@ namespace mu2e {
   template <class KTRAJ> bool KKStrawXing<KTRAJ>::active() const {
     // if the associated hit is active, use it's state. Otherwise use the intrinsic state
     return active_ || (shptr_ && shptr_->hitState().active());
+  }
+
+  template <class KTRAJ> void KKStrawXing<KTRAJ>::updateFromHit(KKSTRAWHITPTR const& strawhit, CA const& ca){
+    shptr_ = strawhit;
+    axis_ = ca.sensorTraj();
+    ca_ = CA(ca);
   }
 
   template <class KTRAJ> void KKStrawXing<KTRAJ>::updateReference(PTRAJ const& ptraj) {


### PR DESCRIPTION
Fixes uninitialized mass in LeadingLog and duplicate straw hit exception in KKFit.

The `LeadingLog_module` previously had an uninitialized `_mass` member, which could lead to `sqrt((E+_mass)(E-_mass))` producing complex numbers and propagating NaNs into Geant4, triggering a `G4RKIntegrationDriver::ComputeNewStepSize` fatal exception. This PR initializes `_mass` from the `ParticleDataList`.
Additionally, `KKFit::addStrawHits` would throw an exception if a `KKStrawXing` already existed for a `StrawId` (e.g., for material correction) and a new `ComboHit` was found for that same straw. This PR modifies `addStrawHits` to update the existing `KKStrawXing` with the new hit information via a new `updateFromHit` method, preventing the `mu2e::addStrawHits: duplicate straw!!` exception.

---
<a href="https://cursor.com/background-agent?bcId=bc-fdd766a9-c4ab-414e-9d59-2d35a8ee3388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fdd766a9-c4ab-414e-9d59-2d35a8ee3388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize particle mass in LeadingLog and update/reuse existing KKStrawXing when adding hits to prevent duplicate-straw exceptions.
> 
> - **Event Generation**:
>   - Initialize `_mass` in `EventGenerator/src/LeadingLog_module.cc` via `ParticleDataList` to use correct kinematics.
> - **KinKal Tracking**:
>   - In `KKFit::addStrawHits` (`Mu2eKinKal/inc/KKFit.hh`), replace duplicate-straw exception with logic to find and update existing `KKStrawXing` using new `updateFromHit`, reusing/augmenting `addexings` as needed.
>   - Add `updateFromHit` API to `KKStrawXing` (`Mu2eKinKal/inc/KKStrawXing.hh`) and wire it to refresh `strawHitPtr` and closest-approach data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c313a7ce5d044803cef6a0b6cca36cf61a93962a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->