### PR TITLE
Handle KalSeedFilter segment reconstruction exception

### DIFF
--- a/Print/src/KalSeedPrinter.cc
+++ b/Print/src/KalSeedPrinter.cc
@@ -62,8 +62,10 @@ void mu2e::KalSeedPrinter::Print(const mu2e::KalSeed& obj, int ind,
 
   os << std::setiosflags(std::ios::fixed | std::ios::right);
   if (ind >= 0 && verbose() == 1) os << std::setw(4) << ind;
+  
+  // Handle KalSeeds with no segments
   double t0;
-  auto seg = obj.t0Segment(t0);
+  auto seg = (obj.segments().size() > 0) ? obj.t0Segment(t0) : obj.segments().end();
 
   if (verbose() >= 1) {
     std::string fittype("Unknown");

--- a/TrkFilters/src/KalSeedFilter_module.cc
+++ b/TrkFilters/src/KalSeedFilter_module.cc
@@ -198,6 +198,12 @@ namespace mu2e
 
     if( Ks.status().hasAllProperties(Cuts._goods) ){
 
+      // Check if KalSeed has segments before proceeding
+      if(Ks.segments().size() == 0) {
+        if(_debug > 2) std::cout << "KalSeedFilter: KalSeed has no segments, skipping" << std::endl;
+        return false;
+      }
+
       // extract test quantities from the fit segment at t0
       double t0;
       auto t0seg = Ks.t0Segment(t0);

--- a/Validation/src/ValKalSeed.cc
+++ b/Validation/src/ValKalSeed.cc
@@ -127,6 +127,9 @@ namespace mu2e {
           vdid = VirtualDetectorId::TT_FrontHollow;
       }
       //
+      // Skip KalSeeds with no segments
+      if(ks.segments().size() == 0) continue;
+      
       double t0;
       auto t0seg = ks.t0Segment(t0);
       double t0var = ks.t0Var();


### PR DESCRIPTION
Add checks for empty `KalSeed` segments to prevent `mu2e::KalSeed: no segments` exceptions.

The `ArtException: mu2e::KalSeed: no segments` occurred because `KalSeed::t0Segment()` throws an exception when called on a `KalSeed` object with no segments. This PR adds checks in `KalSeedFilter`, `ValKalSeed`, and `KalSeedPrinter` to ensure segments exist before calling `t0Segment()`, allowing these modules to gracefully handle (skip or print safely) `KalSeed` objects without segments.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9cac57b-7c5e-466b-84f9-1ec6335af371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f9cac57b-7c5e-466b-84f9-1ec6335af371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add guards for empty `KalSeed` segments to avoid exceptions from `t0Segment()` and handle such seeds by skipping or safe-printing.
> 
> - **TrkFilters (`TrkFilters/src/KalSeedFilter_module.cc`)**:
>   - Add early check for `Ks.segments().size() == 0` to skip seeds and prevent calling `t0Segment()` on empty segments.
> - **Validation (`Validation/src/ValKalSeed.cc`)**:
>   - Skip processing `KalSeed`s with no segments before retrieving `t0Segment()` and filling histograms.
> - **Printing (`Print/src/KalSeedPrinter.cc`)**:
>   - Safely handle seeds with no segments by selecting `seg = segments().end()` when empty and only printing segment-dependent fields if a valid segment exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39af2ac0f2de3f6e4a2f4c82218737a0132fcacd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->